### PR TITLE
Support dynamic import syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ module.exports = {
 + `test`: JS file extension regex. Default: `/\.js($|\?)/i`
 + `comments`: Preserve Comments. Default: `/@preserve|@licen(s|c)e/`. falsy value to remove all comments. Accepts function, object with property test (regex), and values.
 + `sourceMap`: Default: uses [webpackConfig.devtool](https://webpack.js.org/configuration/devtool/). Set this to override that.
++ `plugins`: Specify extra plugins to pass to babel.
++ `parserOpts`: Configure babel with special parser options.
 + `babel`: Pass in a custom babel-core instead. `require("babel-core")`
 + `babili`: Pass in a custom babili preset instead - `require("babel-preset-babili")`.
 ``

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ module.exports = {
 + `test`: JS file extension regex. Default: `/\.js($|\?)/i`
 + `comments`: Preserve Comments. Default: `/@preserve|@licen(s|c)e/`. falsy value to remove all comments. Accepts function, object with property test (regex), and values.
 + `sourceMap`: Default: uses [webpackConfig.devtool](https://webpack.js.org/configuration/devtool/). Set this to override that.
-+ `plugins`: Specify extra plugins to pass to babel.
 + `parserOpts`: Configure babel with special parser options.
 + `babel`: Pass in a custom babel-core instead. `require("babel-core")`
 + `babili`: Pass in a custom babili preset instead - `require("babel-preset-babili")`.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.23.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-babili": "^0.0.12",
     "webpack-sources": "^0.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.23.1",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-babili": "^0.0.12",
     "webpack-sources": "^0.1.4"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ module.exports = class BabiliPlugin {
     const _babel = this.options.babel || babel;
     const _babili = this.options.babili || babiliPreset;
     const parserOpts = this.options.parserOpts || {};
-    const plugins = this.options.plugins || [];
 
     compiler.plugin("compilation", function (compilation) {
       if (useSourceMap) {
@@ -73,7 +72,6 @@ module.exports = class BabiliPlugin {
               const result = _babel.transform(input, {
                 parserOpts,
                 presets: [[_babili, babiliOpts]],
-                plugins,
                 sourceMaps: useSourceMap,
                 babelrc: false,
                 inputSourceMap,

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const babel = require("babel-core");
 const babiliPreset = require("babel-preset-babili");
+const dynamicSyntaxPlugin = require("babel-plugin-syntax-dynamic-import");
 const {SourceMapSource, RawSource} = require("webpack-sources");
 
 module.exports = class BabiliPlugin {
@@ -70,6 +71,7 @@ module.exports = class BabiliPlugin {
               // do the transformation
               const result = _babel.transform(input, {
                 presets: [[_babili, babiliOpts]],
+                plugins: [dynamicSyntaxPlugin],
                 sourceMaps: useSourceMap,
                 babelrc: false,
                 inputSourceMap,

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const babel = require("babel-core");
 const babiliPreset = require("babel-preset-babili");
-const dynamicSyntaxPlugin = require("babel-plugin-syntax-dynamic-import");
 const {SourceMapSource, RawSource} = require("webpack-sources");
 
 module.exports = class BabiliPlugin {
@@ -25,6 +24,8 @@ module.exports = class BabiliPlugin {
 
     const _babel = this.options.babel || babel;
     const _babili = this.options.babili || babiliPreset;
+    const parserOpts = this.options.parserOpts || {};
+    const plugins = this.options.plugins || [];
 
     compiler.plugin("compilation", function (compilation) {
       if (useSourceMap) {
@@ -70,8 +71,9 @@ module.exports = class BabiliPlugin {
 
               // do the transformation
               const result = _babel.transform(input, {
+                parserOpts,
                 presets: [[_babili, babiliOpts]],
-                plugins: [dynamicSyntaxPlugin],
+                plugins,
                 sourceMaps: useSourceMap,
                 babelrc: false,
                 inputSourceMap,


### PR DESCRIPTION
This change makes the plugin handle dynamic import syntax, whereas right now it fails the build. Normally dynamic imports are handled by webpack, however, I found a case where webpack just passes them through without transforming them.

I have the following code:

```js
if (module.hot) {
  module.hot.accept('./root.jsx', async () => {
    mount((await import('./root.jsx')).default);
  });
  module.hot.accept('./reducers', async () => {
    store.replaceReducer((await import('./reducers')).default);
  });
}
```

Webpack outputs the following:

```js
if (false) {
  module.hot.accept('./root.jsx', async () => {
    mount((await import('./root.jsx')).default);
  });
  module.hot.accept('./reducers', async () => {
    store.replaceReducer((await import('./reducers')).default);
  });
}
```

Notice the `import` is not transformed into a webpack require. I believe this is webpack's way of not creating extra chunks when they aren't needed (in this case, they are only needed when using the `HotModuleReplacementPlugin`). Webpack is relying on a minifier to remove the dead code; however, this plugin's Babel configuration doesn't support the dynamic import syntax and so the build fails as soon as this plugin starts parsing the bundle.

Fixes #38.