### PR TITLE
Upgrade babel-preset-babili requirement to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.24.1",
-    "babel-preset-babili": "^0.1.1",
+    "babel-preset-babili": "^0.1.3",
     "webpack-sources": "^0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to ensure the fix in babel/babili#567 doesn't occur in older builds.