### PR TITLE
docs(readme): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ module.exports = {
 
 #### babiliOptions
 
-`babiliOptions` are passed on to the babili preset. Check https://github.com/babel/babili/tree/master/packages/babel-preset-babili#options. `Default: {}`.
+`babiliOptions` are passed on to the babili preset. You can find a list of [all available options](https://github.com/babel/minify/tree/master/packages/babel-preset-minify#options) in the package directory. 
+
+`Default: {}`
 
 #### Overrides
 


### PR DESCRIPTION
Causing build failures over at webpack/webpack.js.org#1510 (and another).

It seems the Babili and the preset were completely renamed. Even the repo link on their NPM page is broken. Note that some more updates to the README to reflect this change are probably warranted.